### PR TITLE
TY-4014 Update the FCM server endpoint

### DIFF
--- a/src/gcm.erl
+++ b/src/gcm.erl
@@ -11,7 +11,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start/2, start/3, stop/1, start_link/2, start_link/3, push/3, push/4]).
+-export([start/2, start/3, stop/1, start_link/2, start_link/3, push/3, push/4, push_from_project/4]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -54,6 +54,9 @@ push(Name, RegIds, Message, Message_Id) ->
 push(Name, RegIds, Message) ->
     ok = gen_server:call(Name, {send, RegIds, Message, undefined}).
 
+push_from_project(Name, ProjectId, RegIds, Message) ->
+    ok = gen_server:call(Name, {send_from_project, RegIds, ProjectId, RegIds, Message}).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -88,9 +91,15 @@ init([Key, ErrorFun]) ->
 %%--------------------------------------------------------------------
 handle_call(stop, _From, State) ->
     {stop, normal, stopped, State};
+
 handle_call({send, RegIds, Message, Message_Id}, _From, #state{key=Key, error_fun=ErrorFun} = State) ->
     ok = cxy_ctl:execute_task(gcm, gcm_request, send, [{RegIds, Message, Message_Id}, {Key, ErrorFun}]),
     {reply, ok, State};
+
+handle_call({send_from_project, ProjectId, RegIds, Message}, _From, #state{key=Key, error_fun=ErrorFun} = State) ->
+    ok = cxy_ctl:execute_task(gcm, gcm_request, send_from_project, [{ProjectId, RegIds, Message}, {Key, ErrorFun}]),
+    {reply, ok, State};
+
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.

--- a/src/gcm_request.erl
+++ b/src/gcm_request.erl
@@ -1,9 +1,11 @@
 -module(gcm_request).
 
 %% API
--export([send/2]).
+-export([send/2, send_from_project/2]).
 
 -define(BASEURL, "https://fcm.googleapis.com/fcm/send").
+-define(PROJECT_BASEURL, "https://fcm.googleapis.com").
+-define(PROJECT_SEND_METHOD, "message:send").
 -define(TIMEOUT, 6000). %% 6 seconds
 -define(CONNECT_TIMEOUT, 3000). %% 3 seconds
 
@@ -48,6 +50,11 @@ send({RegIds, Message, Message_Id}, {Key, ErrorFun}) ->
             lager:error("exception ~p in call to URL: ~p~n", [Exception, ?BASEURL]),
             {http_error, {exception, Exception}}
     end.
+
+send_from_project({ProjectId, RegIds, Message}, {_Key, _ErrorFun}) ->
+    Url = build_project_url(ProjectId, ?PROJECT_SEND_METHOD),
+    lager:info("FCM Project sending push (dry-run): Url=~p \n Message=~p \n RegIds=~p", [Url, Message, RegIds]),
+    ok.
 
 %%%===================================================================
 %%% Internal functions
@@ -95,6 +102,9 @@ parse_results([Result | Results], [RegId | RegIds], ErrorFun, Message) ->
     end;
 parse_results([], [], _ErrorFun, _Message) ->
     ok.
+
+build_project_url(ProjectId, Method) ->
+    ?PROJECT_BASEURL ++ "/v1/projects/" ++ ProjectId ++ "/" ++ Method.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Other possible errors:					%%


### PR DESCRIPTION
# Description

Add function to support send FCM notifications using HTTP v1 API

## Type

- 🚀 Feature

## Changes

- Create function to send notification from a FCM project config
- Build URL endpoint using the project config

##  Related Tickets

- [TY-4014](https://tigertext.atlassian.net/browse/TY-4014)

##  Notes

- The `send_from_project` function is just a dry-run at the moment since there are pending steps to implement

[TY-4014]: https://tigertext.atlassian.net/browse/TY-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ